### PR TITLE
Slight indentation change to class definitions in NeuralNetwork.do.txt

### DIFF
--- a/doc/src/NeuralNet/NeuralNet.do.txt
+++ b/doc/src/NeuralNet/NeuralNet.do.txt
@@ -1576,17 +1576,16 @@ being realizations of this object with different hyperparameters. An implementat
 !bc pycod
 class NeuralNetwork:
     def __init__(
-        self,
-        X_data,
-        Y_data,
-        n_hidden_neurons=50,
-        n_categories=10,
-        epochs=10,
-        batch_size=100,
-        eta=0.1,
-        lmbd=0.0,
+            self,
+            X_data,
+            Y_data,
+            n_hidden_neurons=50,
+            n_categories=10,
+            epochs=10,
+            batch_size=100,
+            eta=0.1,
+            lmbd=0.0):
 
-    ):
         self.X_data_full = X_data
         self.Y_data_full = Y_data
 
@@ -1968,19 +1967,18 @@ import tensorflow as tf
 
 class NeuralNetworkTensorflow:
     def __init__(
-        self,
-        X_train,
-        Y_train,
-        X_test,
-        Y_test,
-        n_neurons_layer1=100,
-        n_neurons_layer2=50,
-        n_categories=2,
-        epochs=10,
-        batch_size=100,
-        eta=0.1,
-        lmbd=0.0,
-    ):
+            self,
+            X_train,
+            Y_train,
+            X_test,
+            Y_test,
+            n_neurons_layer1=100,
+            n_neurons_layer2=50,
+            n_categories=2,
+            epochs=10,
+            batch_size=100,
+            eta=0.1,
+            lmbd=0.0):
         
         # keep track of number of steps
         self.global_step = tf.Variable(0, dtype=tf.int32, trainable=False, name='global_step')
@@ -2740,22 +2738,21 @@ import tensorflow as tf
 
 class ConvolutionalNeuralNetworkTensorflow:
     def __init__(
-        self,
-        X_train,
-        Y_train,
-        X_test,
-        Y_test,
-        n_filters=10,
-        n_neurons_connected=50,
-        n_categories=10,
-        receptive_field=3,
-        stride=1,
-        padding=1,
-        epochs=10,
-        batch_size=100,
-        eta=0.1,
-        lmbd=0.0,
-    ):
+            self,
+            X_train,
+            Y_train,
+            X_test,
+            Y_test,
+            n_filters=10,
+            n_neurons_connected=50,
+            n_categories=10,
+            receptive_field=3,
+            stride=1,
+            padding=1,
+            epochs=10,
+            batch_size=100,
+            eta=0.1,
+            lmbd=0.0):
         
         self.global_step = tf.Variable(0, dtype=tf.int32, trainable=False, name='global_step')
         

--- a/doc/src/NeuralNet/NeuralNet.do.txt
+++ b/doc/src/NeuralNet/NeuralNet.do.txt
@@ -674,7 +674,7 @@ Defining
 and using the Hadamard product of two vectors we can write this as
 !bt
 \[
-\hat{\delta}^L = f'(\hat{z}^L)\circ\frac{\partial {\cal C}}{\partial (\hat{a}L)}.
+\hat{\delta}^L = f'(\hat{z}^L)\circ\frac{\partial {\cal C}}{\partial (\hat{a}^L)}.
 \]
 !et
 


### PR DESCRIPTION
These class constructor definitions are indented so the method arguments line up with the following method code, which makes them harder to read than necessary. 

As per [PEP-8](https://www.python.org/dev/peps/pep-0008/#indentation):

_No:_
```
# Further indentation required as indentation is not distinguishable.
def long_function_name(
    var_one, var_two, var_three,
    var_four):
    print(var_one)
```
_Yes:_
```
# More indentation included to distinguish this from the rest.
def long_function_name(
        var_one, var_two, var_three,
        var_four):
    print(var_one)
```